### PR TITLE
Fix queried elements in document selector query search

### DIFF
--- a/autoleavegooglemeetv1.1.0/background.js
+++ b/autoleavegooglemeetv1.1.0/background.js
@@ -63,7 +63,7 @@ function timefunction() {
 function membersfunction() {
     // console.log("member fxn", obj.value);
     console.log("checking members");
-    if (document.querySelector(".gV3Svc>span").nextElementSibling.innerText < obj.value) {
+    if (document.querySelector(".uGOf1d").innerText < obj.value) {
         console.log("STOP THE MEET");
         try {
 	    window.document.querySelector('[aria-label="Leave call"]').click();

--- a/autoleavegooglemeetv1.1.0/background.js
+++ b/autoleavegooglemeetv1.1.0/background.js
@@ -52,7 +52,7 @@ function timefunction() {
     if (time == obj.value) {
         console.log("STOP THE MEET");
         try {
-            window.document.querySelector(".FbBiwc").click();
+	    window.document.querySelector('[aria-label="Leave call"]').click();
         } catch {
             console.log("ERROR");
         }
@@ -66,7 +66,7 @@ function membersfunction() {
     if (document.querySelector(".gV3Svc>span").nextElementSibling.innerText < obj.value) {
         console.log("STOP THE MEET");
         try {
-            window.document.querySelector(".FbBiwc").click();
+	    window.document.querySelector('[aria-label="Leave call"]').click();
         } catch {
             console.log("ERROR");
         }
@@ -90,7 +90,7 @@ function minutesfunction() {
     else {
         console.log("STOP THE MEET");
         try {
-            window.document.querySelector(".FbBiwc").click();
+	    window.document.querySelector('[aria-label="Leave call"]').click();
         } catch {
             console.log("ERROR");
         }

--- a/autoleavegooglemeetv1.1.0/background.js
+++ b/autoleavegooglemeetv1.1.0/background.js
@@ -40,6 +40,15 @@ chrome.runtime.onMessage.addListener(
     }
 );
 
+function endCall() {
+    console.log("STOP THE MEET");
+    try {
+	window.document.querySelector("button.QQrMi").click();
+    } catch {
+        console.log("ERROR");
+    }
+}
+
 function timefunction() {
     // console.log("time fxn",obj.value);
     const date = new Date();
@@ -50,12 +59,7 @@ function timefunction() {
     let time = hours + ":" + minutes;
     // console.log(time);
     if (time == obj.value) {
-        console.log("STOP THE MEET");
-        try {
-	    window.document.querySelector('[aria-label="Leave call"]').click();
-        } catch {
-            console.log("ERROR");
-        }
+	endCall();
     } else {
         t = setTimeout(timefunction, 60000);
     }
@@ -63,13 +67,8 @@ function timefunction() {
 function membersfunction() {
     // console.log("member fxn", obj.value);
     console.log("checking members");
-    if (document.querySelector(".uGOf1d").innerText < obj.value) {
-        console.log("STOP THE MEET");
-        try {
-	    window.document.querySelector('[aria-label="Leave call"]').click();
-        } catch {
-            console.log("ERROR");
-        }
+    if (window.document.querySelector(".uGOf1d").innerText < obj.value) {
+	endCall();
     }
     else {
         t = setTimeout(membersfunction, 5000);
@@ -85,15 +84,9 @@ function minutesfunction() {
     }
     if (minute >= 0) {
         t = setTimeout(minutesfunction, 1000);
-
     }
     else {
-        console.log("STOP THE MEET");
-        try {
-	    window.document.querySelector('[aria-label="Leave call"]').click();
-        } catch {
-            console.log("ERROR");
-        }
+	endCall();
     }
 
 }


### PR DESCRIPTION
@bhattcodes I discovered your Chrome extension and tried it out myself. Unfortunately it seemed to break at this line in background.js:

```
 try {
            window.document.querySelector(".FbBiwc").click();
        } catch {
            console.log("ERROR");
        }
```

It looks like the Leave call button does not always have a class of "FbBiwc," and the class may have changed since you wrote this script and/or the class may change depending on region and/or how Chrome is configured. The querySelector function returns null and the ERROR message prints.

I made this adjustment to the querySelector function, replacing it with:
```
window.document.querySelector('[aria-label="Leave call"]').click();
```

I believe this change will be more robust because it instead relies on the label of the button, not the class. Hopefully the label will always be "Leave call."